### PR TITLE
add an option to limit the number of connections per port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ ENV NAMESERVERS="208.67.222.222 8.8.8.8 208.67.220.220 8.8.4.4" \
     PORT="80 443" \
     PRE_RESOLVE=0 \
     MODE=tcp \
-    VERBOSE=0
+    VERBOSE=0 \
+    MAX_CONNECTIONS=100
 COPY proxy.py /usr/local/bin/proxy
 
 # Labels

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Limits the maximum number of accepted connections at once per port.
 #### Setting "unlimited" connections
 
 For each port and open connection a subprocess is spawned. Setting
-a number to high might make your host system unresponsive and prevent you from
+a number too high might make your host system unresponsive and prevent you from
 logging in to it. So be very careful with setting this setting to a large number.
 
 The typical linux system can handle up to 32768 so if you need a lot more

--- a/README.md
+++ b/README.md
@@ -34,6 +34,36 @@ Default: `tcp`
 
 Set to `udp` to proxy in UDP mode.
 
+### `MAX_CONNECTIONS`
+
+Default: `100`
+
+Limits the maximum number of accepted connections at once per port.
+
+#### Setting "unlimited" connections
+
+For each port and open connection a subprocess is spawned. Setting
+a number to high might make your host system unresponsive and prevent you from
+logging in to it. So be very careful with setting this setting to a large number.
+
+The typical linux system can handle up to 32768 so if you need a lot more
+parallel open connections make sure to also set the corresponding variables
+on your host system. See
+https://stackoverflow.com/questions/6294133/maximum-pid-in-linux for reference.
+And divide this number by at least the number of ports you are running through
+ docker-whitelist.
+
+#### What happens when the limit is hit?
+
+docker-whitelist basically starts `socat` so the behaviour is the same. In case
+no more subprocesses can be forked:
+ * UDP mode: You won't see a difference on the connecting side. But no more
+ packets are forwarded for new connections until the number of connections for
+ this port is reduced.
+ * TCP mode: docker-whitelist no longer accepts the connection and your
+ connection will wait until the number of connections for this port is reduced.
+ Your connection may time out.
+
 ### `NAMESERVERS`
 
 Default: `208.67.222.222 8.8.8.8 208.67.220.220 8.8.4.4` to use OpenDNS and Google DNS resolution servers by default.

--- a/proxy.py
+++ b/proxy.py
@@ -10,6 +10,7 @@ from dns.resolver import Resolver
 logging.root.setLevel(logging.INFO)
 mode = os.environ["MODE"]
 ports = os.environ["PORT"].split()
+max_connections = os.environ.get("MAX_CONNECTIONS", 100)
 ip = target = os.environ["TARGET"]
 
 # Resolve target if required
@@ -27,7 +28,7 @@ async def netcat(port):
     # Verbose mode
     if os.environ["VERBOSE"] == "1":
         command.append("-v")
-    command += [f"{mode}-listen:{port},fork,reuseaddr",
+    command += [f"{mode}-listen:{port},fork,reuseaddr,max-children={max_connections}",
                 f"{mode}-connect:{ip}:{port}"]
     # Create the process and wait until it exits
     logging.info("Executing: %s", " ".join(command))


### PR DESCRIPTION
Adds an environment variable to limit the number of forks socat creates at max and sets the default to 100.

Socat default is unlimited (risking pushing the server in a state where no threads can be started anymore).

Info @wt-io-it
