### PR TITLE
Add a udp option to expect no answers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ ENV NAMESERVERS="208.67.222.222 8.8.8.8 208.67.220.220 8.8.4.4" \
     PRE_RESOLVE=0 \
     MODE=tcp \
     VERBOSE=0 \
-    MAX_CONNECTIONS=100
+    MAX_CONNECTIONS=100 \
+    UDP_ANSWERS=1
 COPY proxy.py /usr/local/bin/proxy
 
 # Labels

--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ Set to `1` to force using the specified [nameservers](#nameservers) to resolve t
 
 This is especially useful when using a network alias to whitelist an external API.
 
+### `UDP_ANSWERS`
+
+Default: `1`
+
+`1` means the process will wait for an answer from the server before the forked child process terminates (until this happens the connection counts towards the connection limit).
+Set to `0` if no answers are expected from the server, this prevents subprocesses waiting for an answer indefinitely.
+
+Setting to `0` is recommended if you are using this to connect to a syslog server like graylog.
+
 ### `VERBOSE`
 
 Default: `0`

--- a/proxy.py
+++ b/proxy.py
@@ -29,7 +29,7 @@ async def netcat(port):
     # Verbose mode
     if os.environ["VERBOSE"] == "1":
         command.append("-v")
-    if mode.lower() == "udp" and udp_answers == "0":
+    if mode == "udp" and udp_answers == "0":
         command += [f"udp-recv:{port},reuseaddr", f"udp-sendto:{ip}:{port}"]
     else:
         command += [f"{mode}-listen:{port},fork,reuseaddr,max-children={max_connections}",

--- a/proxy.py
+++ b/proxy.py
@@ -12,6 +12,7 @@ mode = os.environ["MODE"]
 ports = os.environ["PORT"].split()
 max_connections = os.environ.get("MAX_CONNECTIONS", 100)
 ip = target = os.environ["TARGET"]
+udp_answers = os.environ.get("UDP_ANSWERS", "1")
 
 # Resolve target if required
 if os.environ["PRE_RESOLVE"] == "1":
@@ -28,8 +29,11 @@ async def netcat(port):
     # Verbose mode
     if os.environ["VERBOSE"] == "1":
         command.append("-v")
-    command += [f"{mode}-listen:{port},fork,reuseaddr,max-children={max_connections}",
-                f"{mode}-connect:{ip}:{port}"]
+    if mode.lower() == "udp" and udp_answers == "0":
+        command += [f"udp-recv:{port},reuseaddr", f"udp-sendto:{ip}:{port}"]
+    else:
+        command += [f"{mode}-listen:{port},fork,reuseaddr,max-children={max_connections}",
+                    f"{mode}-connect:{ip}:{port}"]
     # Create the process and wait until it exits
     logging.info("Executing: %s", " ".join(command))
     process = await asyncio.create_subprocess_exec(*command)


### PR DESCRIPTION
When using the image with syslog servers (e.g. graylog) the current udp mode forks a process for every connection made to the container. Those forked processes wait indefinitely for an answer from the syslog server and fill up the connection limit with every restarted odoo worker.

With this added option (UDP_NO_ANSWERS) one can configure the instance to not expect any answers and prevent this problem.

info @wt-io-it