### PR TITLE
[FIX] proxy.py: fix proxy for python 3.11

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     hooks:
       - id: pyupgrade
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/timothycrosley/isort

--- a/proxy.py
+++ b/proxy.py
@@ -22,7 +22,6 @@ if os.environ["PRE_RESOLVE"] == "1":
     logging.info("Resolved %s to %s", target, ip)
 
 
-@asyncio.coroutine
 async def netcat(port):
     # Use a persistent BusyBox netcat server in listening mode
     command = ["socat"]


### PR DESCRIPTION
on our CI we got the following error during tests:
```
AttributeError: module 'asyncio' has no attribute 'coroutine'. Did you mean: 'coroutines'?
Traceback (most recent call last):
  File "/usr/local/bin/proxy", line 25, in <module>
    @asyncio.coroutine
     ^^^^^^^^^^^^^^^^^
```

As stated in the python documentation, https://docs.python.org/3.10/library/asyncio-task.html#asyncio.coroutine:
> This decorator should not be used for [async def](https://docs.python.org/3.10/reference/compound_stmts.html#async-def) coroutines.

and
> Deprecated since version 3.8, will be removed in version 3.11: Use [async def](https://docs.python.org/3.10/reference/compound_stmts.html#async-def) instead.

Info @wt-io-it