### PR TITLE
fix: add arm image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
           platforms: |
             linux/386
             linux/amd64
+            linux/arm64
           load: false
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache
@@ -146,6 +147,7 @@ jobs:
           platforms: |
             linux/386
             linux/amd64
+            linux/arm64
           load: false
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache


### PR DESCRIPTION
seems to build arm64 fine

examples image:
```
docker buildx build --platform "linux/arm64" -t ghcr.io/kencove/docker-whitelist:latest --push  .
```