### PR TITLE
fix: pin to python 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.10-alpine
 ENTRYPOINT ["dumb-init", "--"]
 CMD ["proxy"]
 RUN apk add --no-cache -t .build build-base &&\

--- a/proxy.py
+++ b/proxy.py
@@ -22,7 +22,6 @@ if os.environ["PRE_RESOLVE"] == "1":
     logging.info("Resolved %s to %s", target, ip)
 
 
-@asyncio.coroutine
 async def netcat(port):
     # Use a persistent BusyBox netcat server in listening mode
     command = ["socat"]


### PR DESCRIPTION
pinned and running on arm but DeprecationWarning(s):
```
/usr/local/bin/proxy:21: DeprecationWarning: please use dns.resolver.Resolver.resolve() instead
  ip = random.choice([answer.address for answer in resolver.query(target)])
INFO:root:Resolved google.com to 142.250.190.110
/usr/local/bin/proxy:26: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
  async def netcat(port):
INFO:root:Executing: socat tcp-listen:80,fork,reuseaddr,max-children=100 tcp-connect:142.250.190.110:80
INFO:root:Executing: socat tcp-listen:443,fork,reuseaddr,max-children=100 tcp-connect:142.250.190.110:443
```