### PR TITLE
[FIX] Adapt code to Python 3.11

### DIFF
--- a/proxy.py
+++ b/proxy.py
@@ -18,11 +18,10 @@ udp_answers = os.environ.get("UDP_ANSWERS", "1")
 if os.environ["PRE_RESOLVE"] == "1":
     resolver = Resolver()
     resolver.nameservers = os.environ["NAMESERVERS"].split()
-    ip = random.choice([answer.address for answer in resolver.query(target)])
+    ip = random.choice([answer.address for answer in resolver.resolve(target)])
     logging.info("Resolved %s to %s", target, ip)
 
 
-@asyncio.coroutine
 async def netcat(port):
     # Use a persistent BusyBox netcat server in listening mode
     command = ["socat"]


### PR DESCRIPTION
As the build is not fixed to a Python version, last build has put Python 3.11 as the target interpreter, and there are an incompatibility in the code and one deprecation that is fixed in this commit.