### PR TITLE
[FIX] Dockerfile: upgrade setuptools before installing with pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ HEALTHCHECK CMD ["healthcheck"]
 RUN apk add --no-cache -t .build build-base curl-dev &&\
     apk add --no-cache socat &&\
     apk add --no-cache libcurl &&\
+    pip install --no-cache-dir --upgrade setuptools &&\
     pip install --no-cache-dir dnspython dumb-init pycurl &&\
     apk del .build
 ENV NAMESERVERS="208.67.222.222 8.8.8.8 208.67.220.220 8.8.4.4" \


### PR DESCRIPTION
Fixes building with `python:3.11-alpine` (edit, need to check why our build is using 3.11 when this is using 3):
```
#7 5.293 Collecting dnspython
#7 5.322   Downloading dnspython-2.7.0-py3-none-any.whl.metadata (5.8 kB)
#7 5.336 Collecting dumb-init
#7 5.344   Downloading dumb-init-1.2.5.post1.tar.gz (11 kB)
#7 5.351   Preparing metadata (setup.py): started
#7 5.911   Preparing metadata (setup.py): finished with status 'done'
#7 6.015 Collecting pycurl
#7 6.023   Downloading pycurl-7.45.6.tar.gz (239 kB)
#7 6.038      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 239.5/239.5 kB 17.6 MB/s eta 0:00:00
#7 6.100   Installing build dependencies: started
#7 8.084   Installing build dependencies: finished with status 'done'
#7 8.085   Getting requirements to build wheel: started
#7 8.285   Getting requirements to build wheel: finished with status 'done'
#7 8.286   Preparing metadata (pyproject.toml): started
#7 8.481   Preparing metadata (pyproject.toml): finished with status 'done'
#7 8.504 Downloading dnspython-2.7.0-py3-none-any.whl (313 kB)
#7 8.511    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 313.6/313.6 kB 66.3 MB/s eta 0:00:00
#7 8.514 Building wheels for collected packages: dumb-init, pycurl
#7 8.514   Building wheel for dumb-init (setup.py): started
#7 8.715   Building wheel for dumb-init (setup.py): finished with status 'error'
#7 8.725   error: subprocess-exited-with-error
#7 8.725   
#7 8.725   × python setup.py bdist_wheel did not run successfully.
#7 8.725   │ exit code: 1
#7 8.725   ╰─> [21 lines of output]
#7 8.725       Traceback (most recent call last):
#7 8.725         File "<string>", line 2, in <module>
#7 8.725         File "<pip-setuptools-caller>", line 34, in <module>
#7 8.725         File "/tmp/pip-install-jo_m3gxf/dumb-init_b0f4a0bfa00f4c3ea4f6b3e669fd1a41/setup.py", line 119, in <module>
#7 8.725           setup(
#7 8.725         File "/usr/local/lib/python3.11/site-packages/setuptools/__init__.py", line 87, in setup
#7 8.725           return distutils.core.setup(**attrs)
#7 8.725                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#7 8.725         File "/usr/local/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 172, in setup
#7 8.725           ok = dist.parse_command_line()
#7 8.725                ^^^^^^^^^^^^^^^^^^^^^^^^^
#7 8.725         File "/usr/local/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 474, in parse_command_line
#7 8.725           args = self._parse_command_opts(parser, args)
#7 8.725                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#7 8.725         File "/usr/local/lib/python3.11/site-packages/setuptools/dist.py", line 1107, in _parse_command_opts
#7 8.725           nargs = _Distribution._parse_command_opts(self, parser, args)
#7 8.725                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#7 8.725         File "/usr/local/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 539, in _parse_command_opts
#7 8.725           if not issubclass(cmd_class, Command):
#7 8.725                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#7 8.725       TypeError: issubclass() arg 1 must be a class
#7 8.725       [end of output]
#7 8.725   
#7 8.725   note: This error originates from a subprocess, and is likely not a problem with pip.
#7 8.725   ERROR: Failed building wheel for dumb-init
#7 8.725   Running setup.py clean for dumb-init
#7 8.926   Building wheel for pycurl (pyproject.toml): started
#7 14.29   Building wheel for pycurl (pyproject.toml): finished with status 'done'
#7 14.29   Created wheel for pycurl: filename=pycurl-7.45.6-cp311-cp311-linux_x86_64.whl size=317993 sha256=c0999d38c104db15c76ee02d69ef5e613c355f80798f38977bcdf824359bb3d0
#7 14.29   Stored in directory: /tmp/pip-ephem-wheel-cache-06s7th4b/wheels/53/ae/42/82256e5553d77ac77913d33d69e8bb37f4f5038bc7ddadef67
#7 14.29 Successfully built pycurl
#7 14.29 Failed to build dumb-init
#7 14.30 ERROR: Could not build wheels for dumb-init, which is required to install pyproject.toml-based projects
```

Different error message than https://github.com/Tecnativa/doodba/pull/651 but updating setuptools still fixes the install.

Info @wt-io-it