### PR TITLE
[FIX] Readme.md since 443 needs to be specified when used

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,6 +10,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.0
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+      - uses: pre-commit/action@v3.0.1

--- a/README.md
+++ b/README.md
@@ -110,10 +110,16 @@ Only used when [pre-resolving](#pre-resolve) is enabled.
 
 ### `PORT`
 
-Default: `80 443`. If you're proxying HTTP/S services, no need to specify!
+**Default:** `80 443` Ports on which the proxy will listen and forward requests.
 
-The port where this service will listen, and where the [target](#target) service is
-expected to be listening on also.
+-   For standard HTTP/HTTPS services, you **do not** need to change anything (the
+    default covers both port 80 and 443).
+-   If you only need to proxy HTTPS (or your service listens on a different port, or you
+    want to restrict the proxy to TLS only), specify:
+    ```yaml
+    environment:
+        PORT: "443"
+    ```
 
 ### `PRE_RESOLVE`
 


### PR DESCRIPTION
Clarify PORT docs to show when to override

- Explain default `80 443` covers both HTTP and HTTPS
- Add example for forcing HTTPS only with `PORT: "443"`
