### PR TITLE
[IMP] Switch from socat to iptables-based transparent TCP proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,14 @@ ENTRYPOINT ["dumb-init", "--"]
 CMD ["proxy"]
 HEALTHCHECK CMD ["healthcheck"]
 RUN apk add --no-cache -t .build build-base curl-dev &&\
-    apk add --no-cache socat &&\
+    apk add --no-cache iptables &&\
     apk add --no-cache libcurl &&\
     pip install --no-cache-dir dnspython dumb-init pycurl &&\
     apk del .build
 ENV NAMESERVERS="208.67.222.222 8.8.8.8 208.67.220.220 8.8.4.4" \
-    PORT="80 443" \
+    PORT="*" \
+    LISTEN_PORT=15000 \
+    RESOLVE_INTERVAL=60 \
     PRE_RESOLVE=0 \
     MODE=tcp \
     VERBOSE=0 \

--- a/README.md
+++ b/README.md
@@ -10,188 +10,162 @@
 
 ## What?
 
-A whitelist proxy that uses socat. 🔌😼
+A transparent TCP whitelist proxy based on iptables and asyncio.
 
 ## Why?
 
-tl;dr: To workaround https://github.com/moby/moby/issues/36174.
+Docker supports internal networks; but when you use them, you cannot
+open outbound connections unless the container is attached to a public
+network.
 
-Basically, Docker supports internal networks; but when you use them, you simply cannot
-open ports from those services, which is not very convenient: you either have full or
-none isolation.
+This proxy allows selected external endpoints to be reachable from
+containers attached to restricted internal networks.
 
-This proxy allows some whitelist endpoints to have network connectivity. It can be used
-for:
+Typical use cases:
 
--   Allowing connection only to some APIs, but not to the rest of the WWW.
--   Exposing ports from a container while still not letting the container access the
-    WWW.
+-   Allowing connections only to specific external APIs.
+-   Allowing limited outbound access while keeping containers isolated.
+-   Whitelisting external services such as SMTP, payment gateways,
+    font/CDN APIs, etc.
 
 ## How?
 
-Use these environment variables:
+The proxy works by:
 
-### `TARGET`
+-   Installing iptables NAT REDIRECT rules (requires `CAP_NET_ADMIN`)
+-   Running a single TCP listener
+-   Redirecting inbound traffic to that listener
+-   Recovering the original destination port using `SO_ORIGINAL_DST`
+-   Forwarding traffic to `TARGET:<original_port>`
 
-Required. It's the host name where the incoming connections will be redirected to.
+Unlike previous versions, this implementation:
 
-### `HTTP_HEALTHCHECK`
+-   Does not spawn one process per port
+-   Uses a single async TCP server
+-   Scales better under load
+-   Handles DNS refresh more reliably
+
+## Required capability
+
+This implementation requires:
+
+``` yaml
+cap_add:
+  - NET_ADMIN
+```
+
+Without this capability, the container cannot configure iptables and
+will fail at startup.
+
+## Environment variables
+
+### TARGET
+
+Required. Hostname where incoming connections will be forwarded.
+
+### PORT
+
+Default: `*` (all TCP ports allowed)
+
+Defines which TCP ports are redirected and proxied.
+
+Examples:
+
+Allow all ports (default):
+
+``` yaml
+environment:
+  TARGET: api.example.com
+```
+
+Restrict to HTTPS only:
+
+``` yaml
+environment:
+  TARGET: api.example.com
+  PORT: "443"
+```
+
+Multiple ports:
+
+``` yaml
+environment:
+  TARGET: api.example.com
+  PORT: "80 443 8080"
+```
+
+Port ranges:
+
+``` yaml
+environment:
+  TARGET: ftp.example.com
+  PORT: "21 50000-51000"
+```
+
+If `PORT` is not set, all TCP ports are allowed.
+
+### PRE_RESOLVE
 
 Default: `0`
 
-Set to `1` to enable healthcheck with pycurl http requests. This is useful if the target
-uses a deployment where the ip of the service gets changed frequently (e.g.
-`accounts.google.com`) and you are using [`PRE_RESOLVE`](#pre_resolve)
+Set to `1` to resolve `TARGET` using the configured `NAMESERVERS`
+instead of the system resolver.
 
-#### Automatically restarting unhealthy proxies
+When enabled, DNS is refreshed periodically.
 
-When you enable the http healthcheck the container marks itself as unhealthy but does
-nothing. (see https://github.com/moby/moby/pull/22719)
+### RESOLVE_INTERVAL
 
-If you want to restart your proxies automatically, you can use
-https://github.com/willfarrell/docker-autoheal.
+Default: `60`
 
-### `HTTP_HEALTHCHECK_URL`
+Interval in seconds to refresh DNS resolution when `PRE_RESOLVE=1`.
+
+If the IP changes, new connections automatically use the new address.
+
+### NAMESERVERS
+
+Default: 208.67.222.222 8.8.8.8 208.67.220.220 8.8.4.4
+
+Used only when `PRE_RESOLVE=1`.
+
+### LISTEN_PORT
+
+Default: `15000`
+
+Internal port where the proxy listens after iptables redirection.
+
+### HTTP_HEALTHCHECK
+
+Default: `0`
+
+Set to `1` to enable HTTP-based healthcheck using pycurl.
+
+### HTTP_HEALTHCHECK_URL
 
 Default: `http://$TARGET/`
 
-Url to use in [`HTTP_HEALTHCHECK`](#http_healthcheck) if enabled. `$TARGET` gets
-replaced inside the url by the configured [`TARGET`](#target).
-
-### `HTTP_HEALTHCHECK_TIMEOUT_MS`
+### HTTP_HEALTHCHECK_TIMEOUT_MS
 
 Default: `2000`
 
-Timeout in milliseconds for http healthcheck. This is used as a timeout for connecting
-and receiving an answer. You may end up with twice the time spend.
-
-### `MODE`
-
-Default: `tcp`
-
-Set to `udp` to proxy in UDP mode.
-
-### `MAX_CONNECTIONS`
-
-Default: `100`
-
-Limits the maximum number of accepted connections at once per port.
-
-#### Setting "unlimited" connections
-
-For each port and open connection a subprocess is spawned. Setting a number too high
-might make your host system unresponsive and prevent you from logging in to it. So be
-very careful with setting this setting to a large number.
-
-The typical linux system can handle up to 32768 so if you need a lot more parallel open
-connections make sure to also set the corresponding variables on your host system. See
-https://stackoverflow.com/questions/6294133/maximum-pid-in-linux for reference. And
-divide this number by at least the number of ports you are running through
-docker-whitelist.
-
-#### What happens when the limit is hit?
-
-docker-whitelist basically starts `socat` so the behaviour is the same. In case no more
-subprocesses can be forked:
-
--   UDP mode: You won't see a difference on the connecting side. But no more packets are
-    forwarded for new connections until the number of connections for this port is
-    reduced.
--   TCP mode: docker-whitelist no longer accepts the connection and your connection will
-    wait until the number of connections for this port is reduced. Your connection may
-    time out.
-
-### `NAMESERVERS`
-
-Default: `208.67.222.222 8.8.8.8 208.67.220.220 8.8.4.4` to use OpenDNS and Google DNS
-resolution servers by default.
-
-Only used when [pre-resolving](#pre-resolve) is enabled.
-
-### `PORT`
-
-**Default:** `80 443` Ports on which the proxy will listen and forward requests.
-
--   For standard HTTP/HTTPS services, you **do not** need to change anything (the
-    default covers both port 80 and 443).
--   If you only need to proxy HTTPS (or your service listens on a different port, or you
-    want to restrict the proxy to TLS only), specify:
-    ```yaml
-    environment:
-        PORT: "443"
-    ```
--   Multiple ports can be specified separated by spaces:
-
-    ```yaml
-    environment:
-        PORT: "80 443 8080"
-    ```
-
--   Port ranges are also supported using the `start-end` syntax:
-
-    ```yaml
-    environment:
-        PORT: "21 50000-51000"
-    ```
-
-    This is especially useful for protocols like FTP in passive mode, where a fixed
-    passive port range must be proxied in addition to the control port.
-
-### `PRE_RESOLVE`
+### SMTP_HEALTHCHECK
 
 Default: `0`
 
-Set to `1` to force using the specified [nameservers](#nameservers) to resolve the
-[target](#target) before proxying.
+Set to `1` to enable SMTP healthcheck using pycurl.
 
-This is especially useful when using a network alias to whitelist an external API.
-
-### `SMTP_HEALTHCHECK`
-
-Default: `0`
-
-Set to `1` to enable healthcheck with pycurl smtp requests. This is useful if the target
-uses a deployment where the ip of the service gets changed frequently (e.g.
-`smtp.eu.sparkpostmail.com`) and you are using [`PRE_RESOLVE`](#pre_resolve)
-
-#### Automatically restarting unhealthy proxies
-
-see [HTTP_HEALTHCHECK](#http_healthcheck)
-
-### `SMTP_HEALTHCHECK_URL`
+### SMTP_HEALTHCHECK_URL
 
 Default: `smtp://$TARGET/`
 
-Url to use in [`SMTP_HEALTHCHECK`](#smtp_healthcheck) if enabled. `$TARGET` gets
-replaced inside the url by the configured [`TARGET`](#target).
-
-### `SMTP_HEALTHCHECK_COMMAND`
+### SMTP_HEALTHCHECK_COMMAND
 
 Default: `HELP`
 
-Enables changing the healthcheck command for servers that do not support `HELP` (e.g.
-for [MailHog](https://github.com/mailhog/MailHog) you can use `QUIT`)
-
-### `SMTP_HEALTHCHECK_TIMEOUT_MS`
+### SMTP_HEALTHCHECK_TIMEOUT_MS
 
 Default: `2000`
 
-Timeout in milliseconds for smtp healthcheck. This is used as a timeout for connecting
-and receiving an answer. You may end up with twice the time spend.
-
-### `UDP_ANSWERS`
-
-Default: `1`
-
-`1` means the process will wait for an answer from the server before the forked child
-process terminates (until this happens the connection counts towards the connection
-limit). Set to `0` if no answers are expected from the server, this prevents
-subprocesses waiting for an answer indefinitely.
-
-Setting to `0` is recommended if you are using this to connect to a syslog server like
-graylog.
-
-### `VERBOSE`
+### VERBOSE
 
 Default: `0`
 
@@ -199,168 +173,18 @@ Set to `1` to log all connections.
 
 ## Example
 
-So say you have a production app called `coolapp` that sends and reads emails, and uses
-Google Font APIs to render some PDF reports.
-
-It is defined in a `docker-compose.yaml` file like this:
-
-```yaml
-# Production deployment
-version: "2.0"
+``` yaml
 services:
-    app:
-        image: Tecnativa/coolapp
-        ports:
-            - "80:80"
-        environment:
-            DB_HOST: db
-        depends_on:
-            - db
-
-    db:
-        image: postgres:alpine
-        volumes:
-            - dbvol:/var/lib/postgresql/data:z
-
-volumes:
-    dbvol:
-```
-
-Now you want to set up a staging environment for your QA team, which includes a fresh
-copy of the production database. To avoid the app to send or read emails, you put all
-into a safe internal network:
-
-```yaml
-# Staging deployment
-version: "2.0"
-services:
-    proxy:
-        image: traefik
-        networks:
-            default:
-            public:
-        ports:
-            - "8080:8080"
-        volumes:
-            # Here you redirect incoming connections to the app container
-            - /etc/traefik/traefik.toml
-
-    app:
-        image: Tecnativa/coolapp
-        environment:
-            DB_HOST: db
-        depends_on:
-            - db
-
-    db:
-        image: postgres:alpine
-
-networks:
-    default:
-        internal: true
-    public:
-```
-
-Now, it turns out your QA detects font problems. Logic! `app` cannot contact
-`fonts.google.com`. Yikes! What to do? 🤷
-
-`tecnativa/whitelist` to the rescue!! 💪🤠
-
-```yaml
-# Staging deployment
-version: "2.0"
-services:
-    fonts_googleapis_proxy:
-        image: tecnativa/whitelist
-        environment:
-            TARGET: fonts.googleapis.com
-            PRE_RESOLVE: 1 # Otherwise it would resolve to localhost
-        networks:
-            # Containers in default restricted network will ask here for fonts
-            default:
-                aliases:
-                    - fonts.googleapis.com
-            # We need public access to "open the door"
-            public:
-
-    fonts_gstatic_proxy:
-        image: tecnativa/whitelist
-        networks:
-            default:
-                aliases:
-                    - fonts.gstatic.com
-            public:
-        environment:
-            TARGET: fonts.gstatic.com
-            PRE_RESOLVE: 1
-
-    proxy:
-        image: traefik
-        networks:
-            default:
-            public:
-        ports:
-            - "8080:8080"
-        volumes:
-            # Here you redirect incoming connections to the app container
-            - /etc/traefik/traefik.toml
-
-    app:
-        image: Tecnativa/coolapp
-        environment:
-            DB_HOST: db
-        depends_on:
-            - db
-
-    db:
-        image: postgres:alpine
-
-networks:
-    default:
-        internal: true
-    public:
-```
-
-And voilà! `app` has fonts, but nothing more. ✋👮
-
-## Development
-
-All the dependencies you need to develop this project (apart from Docker itself) are
-managed with [poetry](https://python-poetry.org/).
-
-To set up your development environment, run:
-
-```bash
-pip install pipx  # If you don't have pipx installed
-pipx install poetry  # Install poetry itself
-poetry install  # Install the python dependencies and setup the development environment
-```
-
-### Testing
-
-To run the tests locally, add `--prebuild` to autobuild the image before testing:
-
-```sh
-poetry run pytest --prebuild
-```
-
-By default, the image that the tests use (and optionally prebuild) is named
-`test:docker-whitelist`. If you prefer, you can build it separately before testing, and
-remove the `--prebuild` flag, to run the tests with that image you built:
-
-```sh
-docker image build -t test:docker-whitelist .
-poetry run pytest
-```
-
-If you want to use a different image, pass the `--image` command line argument with the
-name you want:
-
-```sh
-# To build it automatically
-poetry run pytest --prebuild --image my_custom_image
-
-# To prebuild it separately
-docker image build -t my_custom_image .
-poetry run pytest --image my_custom_image
+  fonts_googleapis_proxy:
+    image: ghcr.io/tecnativa/docker-whitelist:latest
+    cap_add:
+      - NET_ADMIN
+    networks:
+      default:
+        aliases:
+          - fonts.googleapis.com
+      public:
+    environment:
+      TARGET: fonts.googleapis.com
+      PRE_RESOLVE: 1
 ```

--- a/healthcheck.py
+++ b/healthcheck.py
@@ -2,6 +2,8 @@
 
 import logging
 import os
+import socket
+import subprocess
 
 logger = logging.getLogger("healthcheck")
 
@@ -9,41 +11,37 @@ logger = logging.getLogger("healthcheck")
 def error(message, exception=None):
     logger.error(message)
     if exception is None:
-        exit(1)
-    else:
-        raise exception
+        raise SystemExit(1)
+    raise exception
 
 
 def http_healthcheck():
-    """
-    Use pycurl to check if the target server is still responding via proxy.py
-    :return: None
-    """
+    """Use pycurl to check if the target server is still responding via proxy."""
     import re
 
     import pycurl
 
-    check_url = os.environ.get("HTTP_HEALTHCHECK_URL", "http://localhost/")
+    check_url = os.environ.get("HTTP_HEALTHCHECK_URL", "http://$TARGET/")
     check_timeout_ms = int(os.environ.get("HTTP_HEALTHCHECK_TIMEOUT_MS", 2000))
     target = os.environ.get("TARGET", "localhost")
     check_url_with_target = check_url.replace("$TARGET", target)
-    port = re.search("https?://[^:]*(?::([^/]+))?", check_url_with_target)[1]
+
+    port = re.search(r"https?://[^:]*(?::([^/]+))?", check_url_with_target)[1]
     if not port:
         port = "80" if check_url_with_target.startswith("http://") else "443"
-        ports = os.environ.get("PORT").split()
-        if port not in ports:
+        ports = os.environ.get("PORT", "80 443").split()
+        if port not in ports and "*" not in ports:
             port = ports[0]
             check_url_with_target = re.sub(
-                "(https?://[^/]+)", r"\1:{}".format(port), check_url_with_target
+                r"(https?://[^/]+)", rf"\1:{port}", check_url_with_target
             )
-    print("checking %s via 127.0.0.1" % check_url_with_target)
-    logger.info("checking %s via 127.0.0.1" % check_url_with_target)
+
+    logger.info("checking %s via 127.0.0.1:%s", target, port)
     try:
         request = pycurl.Curl()
         request.setopt(pycurl.URL, check_url_with_target)
-        # do not send the request to the target directly but use our own socat proxy process to check if it's still
-        # working
-        request.setopt(pycurl.RESOLVE, ["{}:{}:127.0.0.1".format(target, port)])
+        # Route target:port to loopback so iptables OUTPUT (-o lo) REDIRECT applies.
+        request.setopt(pycurl.RESOLVE, [f"{target}:{port}:127.0.0.1"])
         request.setopt(pycurl.CONNECTTIMEOUT_MS, check_timeout_ms)
         request.setopt(pycurl.TIMEOUT_MS, check_timeout_ms)
         request.perform()
@@ -53,36 +51,33 @@ def http_healthcheck():
 
 
 def smtp_healthcheck():
-    """
-    Use pycurl to check if the target server is still responding via proxy.py
-    :return: None
-    """
+    """Use pycurl to check if the target server is still responding via proxy."""
     import re
 
     import pycurl
 
-    check_url = os.environ.get("SMTP_HEALTHCHECK_URL", "smtp://localhost/")
+    check_url = os.environ.get("SMTP_HEALTHCHECK_URL", "smtp://$TARGET/")
     check_command = os.environ.get("SMTP_HEALTHCHECK_COMMAND", "HELP")
     check_timeout_ms = int(os.environ.get("SMTP_HEALTHCHECK_TIMEOUT_MS", 2000))
     target = os.environ.get("TARGET", "localhost")
     check_url_with_target = check_url.replace("$TARGET", target)
-    port = re.search("smtp://[^:]*(?::([^/]+))?", check_url_with_target)[1]
+
+    port = re.search(r"smtp://[^:]*(?::([^/]+))?", check_url_with_target)[1]
     if not port:
         port = "25"
-        ports = os.environ.get("PORT").split()
-        if port not in ports:
+        ports = os.environ.get("PORT", "25").split()
+        if port not in ports and "*" not in ports:
             port = ports[0]
             check_url_with_target = re.sub(
-                "(smtp://[^/]+)", r"\1:{}".format(port), check_url_with_target
+                r"(smtp://[^/]+)", rf"\1:{port}", check_url_with_target
             )
-    logger.info("checking %s via 127.0.0.1" % check_url_with_target)
+
+    logger.info("checking %s via 127.0.0.1:%s", target, port)
     try:
         request = pycurl.Curl()
         request.setopt(pycurl.URL, check_url_with_target)
         request.setopt(pycurl.CUSTOMREQUEST, check_command)
-        # do not send the request to the target directly but use our own socat proxy process to check if it's still
-        # working
-        request.setopt(pycurl.RESOLVE, ["{}:{}:127.0.0.1".format(target, port)])
+        request.setopt(pycurl.RESOLVE, [f"{target}:{port}:127.0.0.1"])
         request.setopt(pycurl.CONNECTTIMEOUT_MS, check_timeout_ms)
         request.setopt(pycurl.TIMEOUT_MS, check_timeout_ms)
         request.perform()
@@ -92,132 +87,55 @@ def smtp_healthcheck():
 
 
 def process_healthcheck():
-    """
-    Check that at least one socat process exists per port and no more than the number of configured max connections
-    processes exist for each port.
-    :return:
-    """
-    import subprocess
-
-    ports = os.environ["PORT"].split()
-    max_connections = int(os.environ["MAX_CONNECTIONS"])
-    logger.info(
-        "checking socat processes for port(s) %s having at least one and less than %d socat processes"
-        % (ports, max_connections)
-    )
-    socat_processes = (
-        # grep for all processes running socat, ignoring exit code 2
-        # (unreadable file, happens if some process is stopped while grep is running)
-        subprocess.check_output(
-            [
-                "sh",
-                "-c",
-                "grep -R -s socat /proc/[0-9]*/cmdline"
-                " || grep -R -s socat /proc/[0-9]*/cmdline"
-                ' || status=$? && [ "$status" != "2" ]',
-            ]
-        )
-        .decode("utf-8")
-        .split("\n")
-    )
-    # consider only non-empty lines for socat processes not the ones for grep
-    pids = [
-        process.split("/")[2]
-        for process in socat_processes
-        if process and process.endswith("cmdline:socat")
-    ]
-    if len(pids) < len(ports):
-        # if we have less than the number of ports socat processes we do not need to count processes per port and can
-        # fail fast
-        error("Expected at least %d socat processes" % len(ports))
-    port_process_count = {port: 0 for port in ports}
-    for pid in pids:
-        # foreach socat pid we detect the port it's for by checking the last argument (connect to) that ends with
-        # :{ip}:{port} for our processes
-        try:
-            with open("/proc/%d/cmdline" % int(pid)) as fp:
-                # arguments in /proc/.../cmdline are split by null bytes
-                cmd = [part for part in "".join(fp.readlines()).split("\x00") if part]
-                port = cmd[2].split(":")[-1]
-                port_process_count[port] = port_process_count[port] + 1
-        except (IndexError, KeyError):
-            logger.error("ERROR: unexpected command {} {}".format(pid, cmd))
-            raise
-        except (ProcessLookupError, FileNotFoundError):
-            # ignore processes no longer existing (possibly retrieved an answer)
+    """Check proxy process and iptables rules exist."""
+    listen_port = int(os.environ.get("LISTEN_PORT", "15000"))
+    try:
+        with socket.create_connection(("127.0.0.1", listen_port), timeout=1.0):
             pass
-    for port in ports:
-        if port_process_count[port] == 0:
-            error("Missing socat process(es) for port: %s" % port)
-        if port_process_count[port] >= max_connections + 1:
-            error(
-                "More than %d + 1  socat process(es) for port: %s"
-                % (max_connections, port)
-            )
+    except OSError as e:
+        error(f"proxy is not listening on 127.0.0.1:{listen_port}", e)
+    try:
+        subprocess.check_output(["iptables", "-t", "nat", "-S", "WHITELIST_REDIRECT"])
+    except Exception as e:
+        error(
+            "missing iptables nat chain WHITELIST_REDIRECT (CAP_NET_ADMIN required?)", e
+        )
 
 
 def preresolve_healthcheck():
-    """
-    Check that the pre-resolved ip is still valid now for target
-    :return:
-    """
-    from tempfile import gettempdir
+    """If PRE_RESOLVE=1, ensure TARGET resolves via configured NAMESERVERS."""
+    if os.environ.get("PRE_RESOLVE", "0") in {"0", "", "false", "False"}:
+        return
+    from dns.resolver import Resolver
 
-    load_balancing_dns_fs_flag = os.path.join(
-        gettempdir(), "load_balancing_dns_detected"
-    )
-    if not os.path.exists(load_balancing_dns_fs_flag):
-        # only run the resolver check if a previous run didn't flag the target as being dns load-balanced
-        import subprocess
+    target = os.environ.get("TARGET", "")
+    if not target:
+        error("TARGET is empty")
 
-        from dns.resolver import Resolver
+    r = Resolver()
+    r.nameservers = os.environ.get("NAMESERVERS", "8.8.8.8").split()
+    try:
+        answers = r.resolve(target)
+        ips = [a.address for a in answers]
+        if not ips:
+            error(f"{target} resolved to empty set")
+    except Exception as e:
+        error(f"failed to resolve {target} with NAMESERVERS", e)
 
-        pre_resolved_ips = {
-            line.split(":")[2]
-            for line in subprocess.check_output(
-                [
-                    "sh",
-                    "-c",
-                    "grep -R -s '\\(udp\\|tcp\\)-connect:' /proc/[0-9]*/cmdline || grep -R -s '\\(udp\\|tcp\\)-connect:' /proc/[0-9]*/cmdline",
-                ]
-            )
-            .decode("utf-8")
-            .split("\n")
-            if line
-        }
-        resolver = Resolver()
-        resolver.nameservers = os.environ["NAMESERVERS"].split()
-        target = os.environ["TARGET"]
-        resolved_ips = [answer.address for answer in resolver.resolve(target)]
-        for ip in pre_resolved_ips:
-            logger.info(f"checking {target} resolves to {ip}")
-            if ip not in resolved_ips:
-                resolved_ips_2 = [answer.address for answer in resolver.resolve(target)]
-                if resolved_ips_2 == resolved_ips:
-                    error(
-                        f"{target} no longer resolves to {ip}, {resolved_ips}, {resolved_ips_2}"
-                    )
-                else:
-                    resolved_ips_3 = [
-                        answer.address for answer in resolver.resolve(target)
-                    ]
-                    # to make sure we didn't just hit the server switch in dns, we check again before deactivating
-                    # the healthcheck permanently (until the container restarts)
-                    if resolved_ips_3 != resolved_ips_2:
-                        logger.info(
-                            f"{target} seems to be load-balancing with dns ({resolved_ips} != {resolved_ips_2}), "
-                            f"deactivating the resolver healthcheck"
-                        )
-                        with open(f"{load_balancing_dns_fs_flag}", "w") as fp:
-                            fp.write(target)
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+
+    if os.environ.get("HTTP_HEALTHCHECK", "0") == "1":
+        http_healthcheck()
+    elif os.environ.get("SMTP_HEALTHCHECK", "0") == "1":
+        smtp_healthcheck()
+    else:
+        process_healthcheck()
+        preresolve_healthcheck()
+
+    print("OK")
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
-    process_healthcheck()
-    if os.environ["PRE_RESOLVE"] == "1":
-        preresolve_healthcheck()
-    if os.environ.get("HTTP_HEALTHCHECK", "0") == "1":
-        http_healthcheck()
-    if os.environ.get("SMTP_HEALTHCHECK", "0") == "1":
-        smtp_healthcheck()
+    main()

--- a/proxy.py
+++ b/proxy.py
@@ -270,7 +270,13 @@ async def _handle_redirected(
     reader: asyncio.StreamReader, writer: asyncio.StreamWriter, resolver: TargetResolver
 ) -> None:
     sock = writer.get_extra_info("socket")
-    assert isinstance(sock, socket.socket)
+    if sock is None:
+        writer.close()
+        return
+    if not hasattr(sock, "getsockopt"):
+        _LOG.error("No socket/getsockopt available from transport: %r", sock)
+        writer.close()
+        return
 
     try:
         dst_port = _get_original_dst_port(sock)

--- a/proxy.py
+++ b/proxy.py
@@ -4,66 +4,334 @@ import asyncio
 import logging
 import os
 import random
+import socket
+import struct
+import subprocess
+from typing import Iterable, List, Optional
 
 from dns.resolver import Resolver
 
 logging.root.setLevel(logging.INFO)
-mode = os.environ["MODE"]
-max_connections = os.environ.get("MAX_CONNECTIONS", 100)
-ip = target = os.environ["TARGET"]
-udp_answers = os.environ.get("UDP_ANSWERS", "1")
+_LOG = logging.getLogger("whitelist")
 
 
-def _expand_ports(port_tokens):
+def _env_bool(name: str, default: bool = False) -> bool:
+    val = os.environ.get(name)
+    if val is None:
+        return default
+    return val.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except Exception:
+        return default
+
+
+def _expand_ports(port_tokens: Iterable[str]) -> List[int]:
+    ports: List[int] = []
     for token in port_tokens:
         token = token.strip()
         if not token:
             continue
+        if token == "*":
+            ports.append(-1)
+            continue
         if "-" in token:
-            start, end = token.split("-", 1)
-            start = int(start)
-            end = int(end)
+            start_s, end_s = token.split("-", 1)
+            start = int(start_s)
+            end = int(end_s)
             if end < start:
                 raise ValueError(f"Invalid port range: {token}")
-            for p in range(start, end + 1):
-                yield str(p)
+            ports.extend(list(range(start, end + 1)))
         else:
-            yield token
+            ports.append(int(token))
+    return ports
 
 
-ports = list(_expand_ports(os.environ["PORT"].split()))
+MODE = os.environ.get("MODE", "tcp")
+TARGET = os.environ["TARGET"]
+PRE_RESOLVE = _env_bool("PRE_RESOLVE", False)
+LISTEN_PORT = _env_int("LISTEN_PORT", 15000)
+RESOLVE_INTERVAL = _env_int("RESOLVE_INTERVAL", 60)
 
-# Resolve target if required
-if os.environ.get("PRE_RESOLVE", "0") == "1":
-    resolver = Resolver()
-    resolver.nameservers = os.environ["NAMESERVERS"].split()
-    ip = random.choice([answer.address for answer in resolver.resolve(target)])
-    logging.info("Resolved %s to %s", target, ip)
+PORTS = _expand_ports(os.environ.get("PORT", "80 443").split())
+ANY_PORT = -1 in PORTS
+
+# Linux constant from linux/netfilter_ipv4.h
+_SO_ORIGINAL_DST = 80
 
 
-async def netcat(port):
-    # Use a persistent BusyBox netcat server in listening mode
-    command = ["socat"]
-    # Verbose mode
-    if os.environ["VERBOSE"] == "1":
-        command.append("-v")
-    if mode == "udp" and udp_answers == "0":
-        command += [f"udp-recv:{port},reuseaddr", f"udp-sendto:{ip}:{port}"]
+class TargetResolver:
+    def __init__(self, target: str):
+        self.target = target
+        self._resolver: Optional[Resolver] = None
+        if PRE_RESOLVE:
+            r = Resolver()
+            r.nameservers = os.environ.get("NAMESERVERS", "8.8.8.8").split()
+            self._resolver = r
+        self.current_ip: Optional[str] = None
+
+    def resolve_once(self) -> str:
+        if not self._resolver:
+            # System resolver (may resolve to self if you have Docker aliases)
+            return socket.gethostbyname(self.target)
+        answers = self._resolver.resolve(self.target)
+        ips = [a.address for a in answers]
+        if not ips:
+            raise RuntimeError(f"No A records for {self.target}")
+        return random.choice(ips)
+
+    async def keep_fresh(self) -> None:
+        while self.current_ip is None:
+            try:
+                self.current_ip = self.resolve_once()
+                _LOG.info("Resolved %s to %s", self.target, self.current_ip)
+            except Exception as e:
+                _LOG.warning("DNS resolve failed for %s: %s", self.target, e)
+                await asyncio.sleep(2)
+
+        if not PRE_RESOLVE:
+            return
+
+        while True:
+            await asyncio.sleep(max(1, RESOLVE_INTERVAL))
+            try:
+                new_ip = self.resolve_once()
+                if new_ip != self.current_ip:
+                    _LOG.info(
+                        "DNS changed for %s: %s -> %s",
+                        self.target,
+                        self.current_ip,
+                        new_ip,
+                    )
+                    self.current_ip = new_ip
+            except Exception as e:
+                _LOG.warning("DNS refresh failed for %s: %s", self.target, e)
+
+
+def _run(cmd: List[str], *, check: bool = True) -> subprocess.CompletedProcess:
+    if os.environ.get("VERBOSE", "0") not in {"0", "", "false", "False"}:
+        _LOG.info("Executing: %s", " ".join(cmd))
+    return subprocess.run(
+        cmd,
+        check=check,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _iptables_prepare_chain(chain: str) -> None:
+    # Create chain if missing; flush it to keep idempotent behaviour on restarts.
+    _run(["iptables", "-t", "nat", "-N", chain], check=False)
+    _run(["iptables", "-t", "nat", "-F", chain], check=True)
+
+    # Ensure PREROUTING jumps into our chain once (traffic coming from other containers).
+    if (
+        _run(
+            ["iptables", "-t", "nat", "-C", "PREROUTING", "-p", "tcp", "-j", chain],
+            check=False,
+        ).returncode
+        != 0
+    ):
+        _run(
+            ["iptables", "-t", "nat", "-A", "PREROUTING", "-p", "tcp", "-j", chain],
+            check=True,
+        )
+
+    # Ensure OUTPUT on loopback also jumps into our chain (so in-container healthchecks
+    # using 127.0.0.1 benefit from the same REDIRECT rules).
+    if (
+        _run(
+            [
+                "iptables",
+                "-t",
+                "nat",
+                "-C",
+                "OUTPUT",
+                "-o",
+                "lo",
+                "-p",
+                "tcp",
+                "-j",
+                chain,
+            ],
+            check=False,
+        ).returncode
+        != 0
+    ):
+        _run(
+            [
+                "iptables",
+                "-t",
+                "nat",
+                "-A",
+                "OUTPUT",
+                "-o",
+                "lo",
+                "-p",
+                "tcp",
+                "-j",
+                chain,
+            ],
+            check=True,
+        )
+
+
+def _setup_iptables_redirect(
+    listen_port: int, ports: List[int], any_port: bool
+) -> None:
+    """Install REDIRECT rules to send selected inbound TCP ports to listen_port."""
+    chain = "WHITELIST_REDIRECT"
+    _iptables_prepare_chain(chain)
+
+    if any_port:
+        # Redirect all TCP ports except the internal listener port (avoid self-loop).
+        _run(
+            [
+                "iptables",
+                "-t",
+                "nat",
+                "-A",
+                chain,
+                "-p",
+                "tcp",
+                "!",
+                "--dport",
+                str(listen_port),
+                "-j",
+                "REDIRECT",
+                "--to-ports",
+                str(listen_port),
+            ],
+            check=True,
+        )
+        _LOG.info("iptables: redirecting ALL tcp ports -> %s", listen_port)
+        return
+
+    # Redirect explicit ports
+    for p in ports:
+        if p <= 0:
+            continue
+        if p == listen_port:
+            # Avoid redirecting the proxy listener into itself.
+            continue
+        _run(
+            [
+                "iptables",
+                "-t",
+                "nat",
+                "-A",
+                chain,
+                "-p",
+                "tcp",
+                "--dport",
+                str(p),
+                "-j",
+                "REDIRECT",
+                "--to-ports",
+                str(listen_port),
+            ],
+            check=True,
+        )
+    _LOG.info(
+        "iptables: redirecting tcp ports %s -> %s",
+        " ".join(str(p) for p in ports if p > 0),
+        listen_port,
+    )
+
+
+def _get_original_dst_port(conn: socket.socket) -> int:
+    data = conn.getsockopt(socket.SOL_IP, _SO_ORIGINAL_DST, 16)
+    _family, port = struct.unpack_from("!HH", data, 0)
+    return port
+
+
+async def _pipe(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+    try:
+        while True:
+            chunk = await reader.read(65536)
+            if not chunk:
+                break
+            writer.write(chunk)
+            await writer.drain()
+    except Exception:
+        pass
+    finally:
+        try:
+            writer.close()
+            await writer.wait_closed()
+        except Exception:
+            pass
+
+
+async def _handle_redirected(
+    reader: asyncio.StreamReader, writer: asyncio.StreamWriter, resolver: TargetResolver
+) -> None:
+    sock = writer.get_extra_info("socket")
+    assert isinstance(sock, socket.socket)
+
+    try:
+        dst_port = _get_original_dst_port(sock)
+    except Exception as e:
+        _LOG.error("Failed to read original destination (SO_ORIGINAL_DST): %s", e)
+        writer.close()
+        return
+
+    if dst_port == LISTEN_PORT and not ANY_PORT:
+        # Someone connected directly to LISTEN_PORT; this is not a public interface.
+        writer.close()
+        return
+
+    target_ip = resolver.current_ip or TARGET
+    try:
+        r2, w2 = await asyncio.open_connection(target_ip, dst_port)
+    except Exception as e:
+        _LOG.info("Connect failed to %s:%s: %s", target_ip, dst_port, e)
+        writer.close()
+        return
+
+    await asyncio.gather(_pipe(reader, w2), _pipe(r2, writer))
+
+
+async def _main() -> None:
+    if MODE != "tcp":
+        raise SystemExit("This image now supports MODE=tcp only (no socat).")
+
+    resolver = TargetResolver(TARGET)
+    asyncio.create_task(resolver.keep_fresh())
+
+    try:
+        _setup_iptables_redirect(LISTEN_PORT, PORTS, ANY_PORT)
+    except Exception as e:
+        raise SystemExit(
+            "Failed to setup iptables NAT REDIRECT. "
+            "You likely need CAP_NET_ADMIN (docker-compose: cap_add: [NET_ADMIN]). "
+            f"Original error: {e}"
+        )
+
+    server = await asyncio.start_server(
+        lambda r, w: _handle_redirected(r, w, resolver),
+        host="0.0.0.0",
+        port=LISTEN_PORT,
+        backlog=1024,
+    )
+    addrs = ", ".join(str(sock.getsockname()) for sock in server.sockets or [])
+    if ANY_PORT:
+        _LOG.info(
+            "Proxy listening on %s (redirect: ALL tcp ports -> %s)", addrs, LISTEN_PORT
+        )
     else:
-        command += [
-            f"{mode}-listen:{port},fork,reuseaddr,max-children={max_connections}",
-            f"{mode}-connect:{ip}:{port}",
-        ]
-    # Create the process and wait until it exits
-    logging.info("Executing: %s", " ".join(command))
-    process = await asyncio.create_subprocess_exec(*command)
-    await process.wait()
+        _LOG.info(
+            "Proxy listening on %s (redirect: %s -> %s)",
+            addrs,
+            " ".join(str(p) for p in PORTS if p > 0),
+            LISTEN_PORT,
+        )
 
-
-async def _main():
-    # Create tasks within a running event loop (robust on Python 3.10+)
-    tasks = [asyncio.create_task(netcat(port)) for port in ports]
-    await asyncio.gather(*tasks)
+    async with server:
+        await server.serve_forever()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR replaces the per-port socat model with a single asyncio-based
transparent TCP proxy using iptables NAT REDIRECT and SO_ORIGINAL_DST.

The previous implementation spawned one socat process per port, which
introduced scalability and reliability issues (thread/process explosion,
resource consumption, restart complexity, DNS update handling, etc.).

The new design:
- Uses a single TCP listener
- Redirects traffic via iptables
- Automatically handles any TCP port (default behaviour)
- Improves PRE_RESOLVE DNS refresh logic

By default, all TCP ports are now allowed unless PORT is explicitly set.

Requires CAP_NET_ADMIN.
